### PR TITLE
[FEATURE] add Pipette.Stage.Recipe to nest recipes within each other

### DIFF
--- a/lib/pipette/client.ex
+++ b/lib/pipette/client.ex
@@ -101,14 +101,16 @@ defmodule Pipette.Client do
 
   def await_response(ref, monitor, timeout) do
     receive do
-      %IP{value: value, ref: ^ref} ->
+      # TODO: write tests
+      %IP{route: route, value: value, ref: ^ref} ->
         Process.demonitor(monitor)
-        {:ok, value}
+        {route, value}
 
       {:DOWN, ^monitor, _, _, _reason} ->
         {:error, %Error{message: "consumer went down while waiting for return on OUT"}}
 
-      _ ->
+      msg ->
+        Logger.warn("unexpected message on Client.await_response/3: #{inspect msg}")
         await_response(ref, monitor, timeout)
     after
       timeout ->

--- a/lib/pipette/gen_stage.ex
+++ b/lib/pipette/gen_stage.ex
@@ -1,6 +1,6 @@
 defmodule Pipette.GenStage do
   defmacro __using__(opts \\ []) do
-    stage_type = Keyword.fetch!(opts, :stage_type)
+    stage_type = Keyword.get(opts, :stage_type, :producer_consumer)
 
     quote bind_quoted: [stage_type: stage_type] do
       use GenStage
@@ -8,22 +8,22 @@ defmodule Pipette.GenStage do
 
       def stage_type, do: @stage_type
 
-      def child_spec(block, opts \\ []) do
-        %{id: __MODULE__, start: {__MODULE__, :start_link, [block, opts]}}
+      def child_spec(stage, opts \\ []) do
+        %{id: __MODULE__, start: {__MODULE__, :start_link, [stage, opts]}}
       end
 
-      def start_link(block, opts \\ []) do
-        GenStage.start_link(__MODULE__, block, opts)
+      def start_link(stage, opts \\ []) do
+        GenStage.start_link(__MODULE__, stage, opts)
       end
 
-      def init(block) do
+      def init(stage) do
         case @stage_type do
           :consumer ->
-            {:consumer, block}
+            {:consumer, stage}
 
           stage_type when stage_type in [:producer, :producer_consumer] ->
             dispatcher = {GenStage.BroadcastDispatcher, []}
-            {stage_type, block, dispatcher: dispatcher}
+            {stage_type, stage, dispatcher: dispatcher}
         end
       end
 

--- a/lib/pipette/recipe.ex
+++ b/lib/pipette/recipe.ex
@@ -30,14 +30,14 @@ defmodule Pipette.Recipe do
             stages: %{},
             subscriptions: []
 
-  def new(%{id: id, stages: stages, subscriptions: subscriptions}) do
+  def new(%{stages: stages, subscriptions: subscriptions} = recipe) do
     stages =
       stages
       |> Map.put(:IN, stages[:IN] || %Stage.PushProducer{})
       |> Map.put(:OUT, stages[:OUT] || %Stage.Consumer{})
 
     %Recipe{
-      id: id,
+      id: Map.get(recipe, :id),
       stages: stages,
       subscriptions: subscriptions
     }

--- a/lib/pipette/stage/recipe.ex
+++ b/lib/pipette/stage/recipe.ex
@@ -1,0 +1,30 @@
+defmodule Pipette.Stage.Recipe do
+
+  defstruct recipe: nil,
+    timeout: :infinity
+
+  use Pipette.GenStage
+  alias Pipette.Client
+  alias Pipette.IP
+
+  def init(stage) do
+    {:ok, controller} = Pipette.Controller.start_link(stage.recipe, name: nil)
+    {:ok, client} = Client.start_link(controller)
+    state = %{
+      stage: stage,
+      controller: controller,
+      client: client
+    }
+
+    dispatcher = {GenStage.BroadcastDispatcher, []}
+    {:producer_consumer, state, dispatcher: dispatcher}
+  end
+
+  def handle_events([ip], _from, %{stage: stage, client: client} = state) do
+    new_value = Client.call(client, ip.value, stage.timeout)
+    new_ip = IP.update(ip, new_value)
+    {:noreply, [new_ip], state}
+  end
+
+end
+

--- a/test/pipette/controller_test.exs
+++ b/test/pipette/controller_test.exs
@@ -11,7 +11,7 @@ defmodule Pipette.ControllerTest do
       Recipe.new(%{
         id: __MODULE__,
         stages: %{
-          foo: %Stage{handler: fn value -> {value, "message"} end}
+          foo: %Stage{handler: fn route -> {route, "message"} end}
         },
         subscriptions: [
           {:foo, :IN},
@@ -22,8 +22,8 @@ defmodule Pipette.ControllerTest do
       |> Client.start()
 
     assert {:ok, "message"} == Client.call(client, :ok)
-    assert {:ok, "message"} == Client.call(client, :foo)
-    assert {:ok, "message"} == Client.call(client, :bar)
+    assert {:foo, "message"} == Client.call(client, :foo)
+    assert {:bar, "message"} == Client.call(client, :bar)
   end
 
   test "subscribe to all stages of a recipe at once" do

--- a/test/pipette/nested_recipe_test.exs
+++ b/test/pipette/nested_recipe_test.exs
@@ -1,0 +1,103 @@
+defmodule Pipette.NestedRecipeTest do
+  use ExUnit.Case
+  use Pipette.Test
+
+  alias Pipette.Recipe
+  alias Pipette.Stage
+  alias Pipette.Client
+  alias Pipette.IP
+
+  test "nest other recipes with Stage.Recipe" do
+    foo_recipe = Recipe.new(%{
+      stages: %{
+        foo: %Stage{handler: fn
+          "foo" -> "bar"
+          val -> val
+        end}
+      },
+      subscriptions: [
+        {:foo, :IN},
+        {:OUT, :foo}
+      ]
+    })
+
+    string_length = Recipe.new(%{
+      stages: %{
+        inner: %Stage.Recipe{recipe: foo_recipe},
+        len: %Stage{handler: fn val -> {val, String.length(val)} end}
+      },
+      subscriptions: [
+        {:inner, :IN},
+        {:len, :inner},
+        {:OUT, :len}
+      ]
+    })
+
+    assert {"bar", 3} = run_recipe(string_length, "bar")
+  end
+
+  test "nest multiple of the same recipe within each other" do
+    add_one = Recipe.new(%{
+      id: :one,
+      stages: %{
+        one: %Stage{handler: fn val -> val + 1 end}
+      },
+      subscriptions: [
+        {:one, :IN},
+        {:OUT, :one}
+      ]
+    })
+    add_two = Recipe.new(%{
+      id: :two,
+      stages: %{
+        one: %Stage.Recipe{recipe: add_one},
+        two: %Stage.Recipe{recipe: add_one}
+      },
+      subscriptions: [
+        {:one, :IN},
+        {:two, :one},
+        {:OUT, :two}
+      ]
+    })
+    add_three = Recipe.new(%{
+      id: :three,
+      stages: %{
+        two: %Stage.Recipe{recipe: add_two},
+        three: %Stage.Recipe{recipe: add_one}
+      },
+      subscriptions: [
+        {:two, :IN},
+        {:three, :two},
+        {:OUT, :three}
+      ]
+    })
+
+    assert 3 == run_recipe(add_three, 0)
+  end
+
+  test "break a nested recipe on timeout" do
+    nested = Recipe.new(%{
+      stages: %{
+        fun: %Stage{handler: fn -> :timer.sleep(100) end}
+      },
+      subscriptions: [
+        {:fun, :IN},
+        {:OUT, :fun}
+      ]
+    })
+    recipe = Recipe.new(%{
+      stages: %{
+        nested: %Stage.Recipe{recipe: nested, timeout: 50}
+      },
+      subscriptions: [
+        {:nested, :IN},
+        {:OUT, {:nested, :*}}
+      ]
+    })
+    assert %IP{route: :error, value: %Client.TimeoutError{}} =
+      load_recipe(recipe)
+      |> push("foo")
+      |> await()
+  end
+end
+


### PR DESCRIPTION
@theharq check this out, Paul suggest we might just use controller/client to nest recipes.

This is definitely a solution that uses a lot more processes, and is not as elegant as chaining the GenStages together, but it fulfils the purpose.

Performance tests will show what the implications are for this kind of nesting.

I am happy with it. We might just work on a Controller that does the nesting on a GenStage level another time.