### PR TITLE
[FEATURE] Add Pipette.OnDefinition to further improve the way recipe modules can be built

### DIFF
--- a/lib/pipette/on_definition.ex
+++ b/lib/pipette/on_definition.ex
@@ -1,0 +1,26 @@
+defmodule Pipette.OnDefinition do
+
+  defmacro __using__(_opts) do
+    quote do
+      use Pipette.Recipe
+
+      @on_definition Pipette.OnDefinition
+    end
+  end
+
+  def __on_definition__(_env, _kind, name, _args, _guards, _body)
+  when name in [:subscriptions, :stages, :recipe], do: nil
+
+  def __on_definition__(env, :def, name, _args, _guards, _body) do
+    mod = env.module
+    stages = Module.get_attribute(mod, :stage)
+
+    unless Keyword.has_key?(stages, name) do
+      stage = %Pipette.Stage{handler: {mod, name, []}}
+      Module.put_attribute(mod, :stage, {name, stage})
+    end
+  end
+
+  def __on_definition__(_env, _kind, _name, _args, _guards, _body), do: nil
+
+end

--- a/lib/pipette/recipe.ex
+++ b/lib/pipette/recipe.ex
@@ -1,11 +1,24 @@
 defmodule Pipette.Recipe do
+
   defmacro __using__(_opts \\ []) do
     quote do
+      Module.register_attribute __MODULE__, :stage, accumulate: true, persist: true
+      Module.register_attribute __MODULE__, :subscribe, accumulate: true, persist: true
+
       def process_name, do: __MODULE__
 
-      def stages, do: %{}
+      def stages do
+        __MODULE__.__info__(:attributes)
+        |> Keyword.get_values(:stage)
+        |> List.flatten
+        |> Enum.into(%{})
+      end
 
-      def subscriptions, do: []
+      def subscriptions do
+        __MODULE__.__info__(:attributes)
+        |> Keyword.get_values(:subscribe)
+        |> List.flatten
+      end
 
       def recipe do
         Pipette.Recipe.new(%{

--- a/lib/pipette/test.ex
+++ b/lib/pipette/test.ex
@@ -30,30 +30,30 @@ defmodule Pipette.Test do
     load_recipe(module.recipe())
   end
 
-  def push(controller_pid, value) do
+  def push(controller_pid, value) when is_pid(controller_pid) do
     Pipette.Test.Controller.push(controller_pid, value)
   end
 
-  def await(controller_pid, outlet \\ :OUT) do
+  def await(controller_pid, outlet \\ :OUT) when is_pid(controller_pid) do
     Pipette.Test.Controller.await(controller_pid, outlet)
   end
 
-  def await_value(controller_pid, outlet \\ :OUT) do
+  def await_value(controller_pid, outlet \\ :OUT) when is_pid(controller_pid) do
     %Pipette.IP{value: value} = await(controller_pid, outlet)
     value
   end
 
   def run_recipe(recipe_pid_or_module, value, outlet \\ :OUT)
 
-  def run_recipe(%Pipette.Recipe{} = recipe, value, outlet) do
-    recipe
-    |> load_recipe
-    |> run_recipe(value, outlet)
-  end
-
   def run_recipe(pid, value, outlet) when is_pid(pid) do
     pid
     |> push(value)
     |> await_value(outlet)
+  end
+
+  def run_recipe(module, value, outlet) do
+    module
+    |> load_recipe
+    |> run_recipe(value, outlet)
   end
 end

--- a/lib/pipette/test.ex
+++ b/lib/pipette/test.ex
@@ -22,8 +22,12 @@ defmodule Pipette.Test do
     end
   end
 
-  def load_recipe(recipe) do
+  def load_recipe(%Pipette.Recipe{} = recipe) do
     Pipette.Test.Controller.start(recipe)
+  end
+
+  def load_recipe(module) when is_atom(module) do
+    load_recipe(module.recipe())
   end
 
   def push(controller_pid, value) do
@@ -39,7 +43,7 @@ defmodule Pipette.Test do
     value
   end
 
-  def run_recipe(recipe_or_pid, value, outlet \\ :OUT)
+  def run_recipe(recipe_pid_or_module, value, outlet \\ :OUT)
 
   def run_recipe(%Pipette.Recipe{} = recipe, value, outlet) do
     recipe

--- a/test/pipette/macro_test.exs
+++ b/test/pipette/macro_test.exs
@@ -1,0 +1,53 @@
+defmodule Pipette.MacroTest do
+  use ExUnit.Case
+  use Pipette.Test
+
+  defmodule TestModule do
+    use Pipette.OnDefinition
+
+    @subscribe foo: :IN
+    @subscribe OUT: {:foo, :*}
+
+    def foo("foo"), do: "bar"
+
+    def foo("err"), do: {:error, "err"}
+
+    def foo(num) when is_number(num), do: to_string(num)
+
+    def foo(val), do: val
+
+    def foo(), do: private()
+
+    defp private, do: "do not list me"
+  end
+
+  test "TestModule" do
+    assert "bar" == TestModule.foo("foo")
+    assert {:error, "err"} == TestModule.foo("err")
+    assert "123" == TestModule.foo(123)
+    assert "123" == TestModule.foo(123)
+  end
+
+  test "@subscribe accumulates subscriptions" do
+    assert [
+      {:foo, :IN},
+      {:OUT, {:foo, :*}}
+    ] == TestModule.subscriptions()
+  end
+
+  test "stages returns all public functions of the module, defined after use Pipette.Recipe" do
+    assert %{
+      foo: %Pipette.Stage{handler: {TestModule, :foo, []}}
+    } == TestModule.stages()
+  end
+
+  test "TestModule represents a fully functional recipe" do
+    controller = load_recipe(TestModule)
+    assert "bar" == run_recipe controller, "foo"
+    assert "foo" == run_recipe controller, "foo", :IN
+    assert %Pipette.IP{route: :error, value: "err"} = controller
+                                                      |> push("err")
+                                                      |> await()
+  end
+
+end

--- a/test/pipette/recipe_test.exs
+++ b/test/pipette/recipe_test.exs
@@ -15,43 +15,30 @@ defmodule Pipette.RecipeTest do
       {:via, Registry, {Registry.ViaTest, :registered}}
     end
 
-    def stages,
-      do: %{
-        add_one: %Stage{handler: &(&1 + 1)}
-      }
-
-    def subscriptions,
-      do: [
-        {:add_one, :IN},
-        {:OUT, :add_one}
-      ]
+    @stage add_one: %Stage{handler: &(&1 + 1)}
+    @subscribe add_one: :IN
+    @subscribe OUT: :add_one
   end
 
   defmodule FooToBarRecipe do
     use Pipette.Recipe
 
-    def stages,
-      do: %{
-        foo_to_bar: %Stage{
-          handler: fn
-            "foo" -> "bar"
-            other -> other
-          end
-        },
-        zig_to_zag: %Stage{
-          handler: fn
-            "zig" -> "zag"
-            other -> other
-          end
-        }
-      }
+    @stage foo_to_bar: %Stage{
+      handler: fn
+        "foo" -> "bar"
+        other -> other
+      end
+    }
+    @stage zig_to_zag: %Stage{
+      handler: fn
+        "zig" -> "zag"
+        other -> other
+      end
+    }
 
-    def subscriptions,
-      do: [
-        {:foo_to_bar, :IN},
-        {:zig_to_zag, :foo_to_bar},
-        {:OUT, :zig_to_zag}
-      ]
+    @subscribe foo_to_bar: :IN
+    @subscribe zig_to_zag: :foo_to_bar
+    @subscribe OUT: :zig_to_zag
   end
 
   test "#start_link starts a controlled recipe" do

--- a/test/pipette/test_test.exs
+++ b/test/pipette/test_test.exs
@@ -7,21 +7,12 @@ defmodule Pipette.TestTest do
   defmodule FooBarRecipe do
     use Pipette.Recipe
 
-    def stages,
-      do: %{
-        foo: %Pipette.Stage{
-          handler: fn
-            "foo" -> "bar"
-            val -> val
-          end
-        }
-      }
-
-    def subscriptions,
-      do: [
-        {:foo, :IN},
-        {:OUT, :foo}
-      ]
+    @stage foo: %Pipette.Stage{handler: fn
+      "foo" -> "bar"
+      val -> val
+    end}
+    @subscribe foo: :IN
+    @subscribe OUT: :foo
   end
 
   test "#load_recipe starts a test recipe controller" do
@@ -73,7 +64,8 @@ defmodule Pipette.TestTest do
              |> run_recipe("foo", :IN)
   end
 
-  test "#run_recipe takes an atom and and starts the defined recipe" do
-    assert "foo" == run_recipe(FooBarRecipe, "foo", :IN)
+  test "#run_recipe takes a module and starts the defined recipe" do
+    assert "bar" == run_recipe(FooBarRecipe, "foo")
   end
+
 end

--- a/test/pipette/test_test.exs
+++ b/test/pipette/test_test.exs
@@ -4,70 +4,76 @@ defmodule Pipette.TestTest do
 
   alias Pipette.IP
 
-  def recipe() do
-    Pipette.Recipe.new(%{
-      id: __MODULE__,
-      stages: %{
+  defmodule FooBarRecipe do
+    use Pipette.Recipe
+
+    def stages,
+      do: %{
         foo: %Pipette.Stage{
           handler: fn
             "foo" -> "bar"
             val -> val
           end
         }
-      },
-      subscriptions: [
+      }
+
+    def subscriptions,
+      do: [
         {:foo, :IN},
         {:OUT, :foo}
       ]
-    })
   end
 
   test "#load_recipe starts a test recipe controller" do
-    pid = load_recipe(recipe())
+    pid = load_recipe(FooBarRecipe.recipe())
     assert is_pid(pid)
     assert Process.alive?(pid)
   end
 
   test "#push pushes a message onto IN of the recipe" do
-    pid = load_recipe(recipe())
+    pid = load_recipe(FooBarRecipe.recipe())
     push(pid, "foo")
     assert await_value(pid, :IN) == "foo"
   end
 
   test "#await_value waits for a message on OUT" do
     assert "bar" ==
-             load_recipe(recipe())
+             load_recipe(FooBarRecipe.recipe())
              |> push("foo")
              |> await_value()
   end
 
   test "#await waits for a message and returns the IP" do
     assert %IP{value: "bar"} =
-             load_recipe(recipe())
+             load_recipe(FooBarRecipe.recipe())
              |> push("foo")
              |> await()
 
     assert %IP{value: "foo"} =
-             load_recipe(recipe())
+             load_recipe(FooBarRecipe.recipe())
              |> push("foo")
              |> await(:IN)
   end
 
   test "#run_recipe starts a recipe, puts a message on IN and awaits OUT" do
-    assert "bar" == run_recipe(recipe(), "foo")
+    assert "bar" == run_recipe(FooBarRecipe.recipe(), "foo")
   end
 
   test "#run_recipe starts a recipe, puts a message on IN and awaits on a given stage" do
-    assert "foo" == run_recipe(recipe(), "foo", :IN)
+    assert "foo" == run_recipe(FooBarRecipe.recipe(), "foo", :IN)
   end
 
   test "#run_recipe puts a message on IN and awaits the result for a started recipe" do
     assert "bar" ==
-             load_recipe(recipe())
+             load_recipe(FooBarRecipe.recipe())
              |> run_recipe("foo")
 
     assert "foo" ==
-             load_recipe(recipe())
+             load_recipe(FooBarRecipe.recipe())
              |> run_recipe("foo", :IN)
+  end
+
+  test "#run_recipe takes an atom and and starts the defined recipe" do
+    assert "foo" == run_recipe(FooBarRecipe, "foo", :IN)
   end
 end

--- a/test/support/nyc_bike_shares.ex
+++ b/test/support/nyc_bike_shares.ex
@@ -21,24 +21,16 @@ defmodule NYCBikeShares do
   use Pipette.Recipe
   alias Pipette.Stage
 
-  def stages,
-    do: %{
-      IN: %Stage.Producer{
-        handler: fn -> "http://feeds.citibikenyc.com/stations/stations.json" end
-      },
-      fetch: %Stage{handler: GetHTTP},
-      station_list: %Stage{handler: {Pick, key: "stationBeanList"}},
-      station_count: %Stage{handler: fn list -> Enum.count(list) end},
-      filter: %Stage{handler: {Filter, key: "stationName", value: "W 52 St & 11 Ave"}},
-      station: %Stage{handler: &List.first/1}
-    }
+  @stage IN: %Stage.Producer{handler: fn -> "http://feeds.citibikenyc.com/stations/stations.json" end}
+  @stage fetch: %Stage{handler: GetHTTP}
+  @stage station_list: %Stage{handler: {Pick, key: "stationBeanList"}}
+  @stage station_count: %Stage{handler: fn list -> Enum.count(list) end}
+  @stage filter: %Stage{handler: {Filter, key: "stationName", value: "W 52 St & 11 Ave"}}
+  @stage station: %Stage{handler: &List.first/1}
 
-  def subscriptions,
-    do: [
-      {:fetch, :IN},
-      {:station_list, :fetch},
-      {:filter, :station_list},
-      {:station, :filter},
-      {:station_count, :station_list}
-    ]
+  @subscribe fetch: :IN
+  @subscribe station_list: :fetch
+  @subscribe filter: :station_list
+  @subscribe station: :filter
+  @subscribe station_count: :station_list
 end


### PR DESCRIPTION
Basic support for defining module based recipes. Now with less-magic™, and not forced upon the user. User can still use `use Pipette.Recipe` or define its very own module/controller start.

```elixir
  defmodule ExampleRecipe do
    use Pipette.OnDefinition

    @subscribe foo: :IN
    @subscribe OUT: {:foo, :*}

    def foo("foo"), do: "bar"

    def foo("err"), do: {:error, "err"}

    def foo(val), do: val

  end
```

```elixir
  defmodule AnotherExample do
    use Pipette.Recipe

    @subscribe foo: :IN
    @subscribe OUT: {:foo, :*}

    @stage foo: %Pipette.Stage{handler: fn
      "foo" -> "bar"
      val -> val
    end}

  end
```

* `Pipette.OnDefinition` Assumes all public function definitions serve as a stage
* `Pipette.Recipe` respects `@stage` and `@subscribe` module attributes by default
* Changed some examples to use @stage and @subscribe