### PR TITLE
[FEATURE] Validate IP.ref of handler output

### DIFF
--- a/lib/pipette/error.ex
+++ b/lib/pipette/error.ex
@@ -1,0 +1,5 @@
+defmodule Pipette.Error do
+  defmodule InvalidIP do
+    defexception message: nil
+  end
+end

--- a/lib/pipette/handler.ex
+++ b/lib/pipette/handler.ex
@@ -8,9 +8,10 @@ defmodule Pipette.Handler do
   @callback call(value :: any, args :: list(any), ip :: IP.t()) :: return_t
   @optional_callbacks call: 0, call: 1, call: 2, call: 3
 
-  def handle(handler, %IP{} = ip) do
+  def handle(handler, %IP{ref: ref} = ip) do
     case perform(handler, ip) do
-      %IP{} = ip -> ip
+      %IP{ref: ^ref} = ip -> ip
+      %IP{} -> raise Pipette.Error.InvalidIP, "IP.ref mismatch"
       value -> IP.update(ip, value)
     end
   end

--- a/test/pipette/handler_test.exs
+++ b/test/pipette/handler_test.exs
@@ -55,10 +55,14 @@ defmodule Pipette.HandlerTest do
   end
 
   test "#handle returns a new IP", %{ip: ip} do
-    new_ip = Handler.handle(fn _ -> IP.new("bar") end, ip)
+    new_ip = Handler.handle(fn _, _, ip -> IP.set_context(ip, :foo, :bar) end, ip)
+    assert %IP{context: %{foo: :bar}} = new_ip
+  end
 
-    assert %IP{route: :ok, value: "bar"} = new_ip
-    assert new_ip.ref != ip.ref
+  test "#handle raises an error if the new IP ref doesn't match", %{ip: %IP{ref: ref} = ip} do
+    assert_raise Pipette.Error.InvalidIP, "IP.ref mismatch", fn ->
+      Handler.handle(fn _ -> IP.new("foo") end, ip)
+    end
   end
 
   test "#perform handles a module without arguments", %{ip: ip} do


### PR DESCRIPTION
In order to not break recipes by mistakenly not copying the IP reference, the handler output is validated.