### PR TITLE
Feat/client accept ip

### DIFF
--- a/lib/pipette/ip.ex
+++ b/lib/pipette/ip.ex
@@ -22,7 +22,17 @@ defmodule Pipette.IP do
     %IP{ip | route: route, value: value}
   end
 
-  def update(%IP{} = ip, value), do: update(ip, {:ok, value})
+  def update(%IP{} = ip, value) do
+    update(ip, {:ok, value})
+  end
+
+  def set(%IP{} = ip, :value, value) do
+    update(ip, value)
+  end
+
+  def set(%IP{} = ip, field, value) when field in [:route, :ref, :reply_to] do
+    Map.put(ip, field, value)
+  end
 
   def set_context(%IP{} = ip, key, value)
       when is_atom(key) do


### PR DESCRIPTION
I've a pretty bad internet connection at the moment and the NYCBikeShares test is not running. Don't know if it's a bug in the implementation or my bad connection. Anyways, we should use cassettes, to not make actual requests in tests.

I'm going to check the tests tomorrow in the office again.