### PR TITLE
[FEATURE] Add option to #load_recipe, to keep the producer

### DIFF
--- a/lib/pipette/test.ex
+++ b/lib/pipette/test.ex
@@ -22,12 +22,14 @@ defmodule Pipette.Test do
     end
   end
 
-  def load_recipe(%Pipette.Recipe{} = recipe) do
-    Pipette.Test.Controller.start(recipe)
+  def load_recipe(recipe_or_module, args \\ [])
+
+  def load_recipe(%Pipette.Recipe{} = recipe, args) do
+    Pipette.Test.Controller.start(recipe, args)
   end
 
-  def load_recipe(module) when is_atom(module) do
-    load_recipe(module.recipe())
+  def load_recipe(module, args) when is_atom(module) do
+    load_recipe(module.recipe(), args)
   end
 
   def push(controller_pid, value) when is_pid(controller_pid) do

--- a/test/pipette/test_test.exs
+++ b/test/pipette/test_test.exs
@@ -4,21 +4,55 @@ defmodule Pipette.TestTest do
 
   alias Pipette.IP
 
+  defmodule CustomProducer do
+    use Pipette.GenStage, stage_type: :producer
+
+    defstruct handler: {__MODULE__, :add_one}
+
+    def handle_cast(%Pipette.IP{} = ip, %__MODULE__{handler: handler} = stage) do
+      new_ip = Pipette.Handler.handle(handler, ip)
+      {:noreply, [new_ip], stage}
+    end
+
+    def handle_demand(_demand, block) do
+      {:noreply, [], block}
+    end
+
+    def add_one(value), do: value + 1
+  end
+
   defmodule FooBarRecipe do
     use Pipette.Recipe
 
-    @stage foo: %Pipette.Stage{handler: fn
-      "foo" -> "bar"
-      val -> val
-    end}
+    @stage foo: %Pipette.Stage{
+             handler: fn
+               "foo" -> "bar"
+               val -> val
+             end
+           }
     @subscribe foo: :IN
     @subscribe OUT: :foo
+  end
+
+  defmodule CustomProducerRecipe do
+    use Pipette.Recipe
+
+    @stage IN: %CustomProducer{}
+    @subscribe OUT: :IN
   end
 
   test "#load_recipe starts a test recipe controller" do
     pid = load_recipe(FooBarRecipe.recipe())
     assert is_pid(pid)
     assert Process.alive?(pid)
+  end
+
+  test "#load_recipe can keep the original producer" do
+    pid = load_recipe(CustomProducerRecipe, keep_producer: true)
+    assert is_pid(pid)
+    assert Process.alive?(pid)
+    push(pid, 1)
+    assert await_value(pid, :IN) == 2
   end
 
   test "#push pushes a message onto IN of the recipe" do
@@ -67,5 +101,4 @@ defmodule Pipette.TestTest do
   test "#run_recipe takes a module and starts the defined recipe" do
     assert "bar" == run_recipe(FooBarRecipe, "foo")
   end
-
 end


### PR DESCRIPTION
Tests need a push producer in order to run a recipe. When providing a custom push producer, one might keep it in testing