### PR TITLE
[FEATURE] Support custom handler

### DIFF
--- a/lib/pipette/handler.ex
+++ b/lib/pipette/handler.ex
@@ -8,6 +8,12 @@ defmodule Pipette.Handler do
   @callback call(value :: any, args :: list(any), ip :: IP.t()) :: return_t
   @optional_callbacks call: 0, call: 1, call: 2, call: 3
 
+  @handler Application.get_env(:pipette, :handler, Pipette.Handler)
+
+  def call(handler, ip) do
+    @handler.handle(handler, ip)
+  end
+
   def handle(handler, %IP{ref: ref} = ip) do
     case perform(handler, ip) do
       %IP{ref: ^ref} = ip -> ip

--- a/lib/pipette/stage.ex
+++ b/lib/pipette/stage.ex
@@ -17,7 +17,7 @@ defmodule Pipette.Stage do
   end
 
   defp process_ip(%IP{} = ip, %__MODULE__{handler: handler} = stage) do
-    Pipette.Handler.handle(handler, ip)
+    Pipette.Handler.call(handler, ip)
   rescue
     error ->
       message = Exception.message(error)

--- a/lib/pipette/stage/consumer.ex
+++ b/lib/pipette/stage/consumer.ex
@@ -13,7 +13,7 @@ defmodule Pipette.Stage.Consumer do
   end
 
   def handle_events([ip], _from, %__MODULE__{handler: handler} = stage) do
-    Pipette.Handler.handle(handler, ip)
+    Pipette.Handler.call(handler, ip)
     {:noreply, [], stage}
   end
 end

--- a/lib/pipette/stage/producer.ex
+++ b/lib/pipette/stage/producer.ex
@@ -16,7 +16,7 @@ defmodule Pipette.Stage.Producer do
   def handle_demand(demand, %__MODULE__{handler: handler} = stage) when demand > 0 do
     ips =
       Enum.map(1..demand, fn _ ->
-        Pipette.Handler.handle(handler, IP.new(nil))
+        Pipette.Handler.call(handler, IP.new(nil))
       end)
 
     {:noreply, ips, stage}

--- a/test/pipette/handler_test.exs
+++ b/test/pipette/handler_test.exs
@@ -41,27 +41,27 @@ defmodule Pipette.HandlerTest do
     {:ok, %{ip: ip}}
   end
 
-  test "#handle updates the value of the given IP", %{ip: ip} do
+  test "#call updates the value of the given IP", %{ip: ip} do
     ip_ref = ip.ref
 
-    assert %IP{route: :ok, value: "bar", ref: ^ip_ref} = Handler.handle(fn _ -> "bar" end, ip)
+    assert %IP{route: :ok, value: "bar", ref: ^ip_ref} = Handler.call(fn _ -> "bar" end, ip)
   end
 
-  test "#handle update the route of the IP", %{ip: ip} do
+  test "#call update the route of the IP", %{ip: ip} do
     ip_ref = ip.ref
 
     assert %IP{route: :error, value: "bar", ref: ^ip_ref} =
-             Handler.handle(fn _ -> {:error, "bar"} end, ip)
+             Handler.call(fn _ -> {:error, "bar"} end, ip)
   end
 
-  test "#handle returns a new IP", %{ip: ip} do
-    new_ip = Handler.handle(fn _, _, ip -> IP.set_context(ip, :foo, :bar) end, ip)
+  test "#call returns a new IP", %{ip: ip} do
+    new_ip = Handler.call(fn _, _, ip -> IP.set_context(ip, :foo, :bar) end, ip)
     assert %IP{context: %{foo: :bar}} = new_ip
   end
 
-  test "#handle raises an error if the new IP ref doesn't match", %{ip: %IP{} = ip} do
+  test "#call raises an error if the new IP ref doesn't match", %{ip: %IP{} = ip} do
     assert_raise Pipette.Error.InvalidIP, "IP.ref mismatch", fn ->
-      Handler.handle(fn _ -> IP.new("foo") end, ip)
+      Handler.call(fn _ -> IP.new("foo") end, ip)
     end
   end
 

--- a/test/pipette/test_test.exs
+++ b/test/pipette/test_test.exs
@@ -10,7 +10,7 @@ defmodule Pipette.TestTest do
     defstruct handler: {__MODULE__, :add_one}
 
     def handle_cast(%Pipette.IP{} = ip, %__MODULE__{handler: handler} = stage) do
-      new_ip = Pipette.Handler.handle(handler, ip)
+      new_ip = Pipette.Handler.call(handler, ip)
       {:noreply, [new_ip], stage}
     end
 


### PR DESCRIPTION
This enables the user to switch from the default Pipette.Handler to a custom Handler. A custom handler could do some pre- or post-processing to the IP or the given handler definition.

Example:

```ex
defmodule MapProtocolHandler do
  alias Pipette.IP

  # Run the handler and assigning the result to the key specified in the
  # arguments
  def handle(handler, %IP{value: %{} = map} = ip) do
    %IP{route: route, value: new_value} = new_ip = Pipette.Handler.handle(handler, ip)
    result_value = compose_result(map, new_value)
    IP.update(new_ip, {route, result_value})
  end

  defp compose_result(%{} = map, new_value, handler) do
    args = get_args(handler)
    case args[:RESULT_KEY] do
      key -> Map.put(map, key, new_value)
      _ -> new_value
    end
  end
end
```

```ex
config :pipette, handler: MapProtocolHandler
```