### PR TITLE
Feat/custom start stage

### DIFF
--- a/lib/pipette/handler.ex
+++ b/lib/pipette/handler.ex
@@ -111,6 +111,8 @@ defmodule Pipette.Handler do
   @doc false
   def perform({module, function_name, args}, %IP{value: value} = ip)
       when is_atom(module) and is_atom(function_name) do
+    {:module, ^module} = Code.ensure_loaded(module)
+
     cond do
       function_exported?(module, function_name, 3) ->
         apply(module, function_name, [value, args, ip])

--- a/lib/pipette/handler.ex
+++ b/lib/pipette/handler.ex
@@ -37,11 +37,14 @@ defmodule Pipette.Handler do
 
   alias Pipette.IP
 
-  @type t :: fun()
-           | module()
-           | {module(), keyword()}
-           | {module(), atom()}
-           | {module(), atom(), keyword()}
+  require Logger
+
+  @type t ::
+          fun()
+          | module()
+          | {module(), keyword()}
+          | {module(), atom()}
+          | {module(), atom(), keyword()}
 
   @typedoc """
   The expected return type from any handler call.
@@ -120,6 +123,9 @@ defmodule Pipette.Handler do
 
       function_exported?(module, function_name, 0) ->
         apply(module, function_name, [])
+
+      true ->
+        raise "Handler function not found (module: #{module}, function: #{function_name})"
     end
   end
 end


### PR DESCRIPTION
The method to start a stage can be configured in the main application. We use this in our application, to read some stage configurations from the applications configuration.

```elixir
config :pipette, start_stage: {FooModule, :start_stage, bar: "baz"}

defmodule FooModule do
  def start_stage(%{__struct__: module} = stage, args) when is_atom(module) do
    stage_conf(stage)
    |> Pipette.Controller.start_stage(args)
  end

  defp stage_conf({:cfg, key}), do: Application.get_env(:my_app, key)

  defp stage_conf(%{__struct__: module} = struct) when is_atom(module) do
    Map.from_struct(struct)
    |> stage_conf()
    |> (&struct(module, &1)).()
  end

  defp stage_conf(%{} = map) do
    Enum.map(map, fn {key, value} -> {key, stage_conf(value)} end)
    |> Map.new()
  end

  defp stage_conf(tuple) when is_tuple(tuple) do
    Tuple.to_list(tuple)
    |> stage_conf()
    |> List.to_tuple()
  end

  defp stage_conf(list) when is_list(list), do: Enum.map(list, &stage_conf(&1))
  defp stage_conf(value), do: value
end
```